### PR TITLE
Update usage of Spring boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>
@@ -121,7 +127,6 @@
                     <registryUrl>https://index.docker.io/v1/</registryUrl>
                 </configuration>
             </plugin>
-
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.4.3.RELEASE</version>
+        <version>1.5.3.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/src/main/java/org/zerhusen/JwtDemoApplication.java
+++ b/src/main/java/org/zerhusen/JwtDemoApplication.java
@@ -1,9 +1,11 @@
 package org.zerhusen;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@EnableAutoConfiguration
 public class JwtDemoApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/zerhusen/properties/jwt/Authentication.java
+++ b/src/main/java/org/zerhusen/properties/jwt/Authentication.java
@@ -1,0 +1,29 @@
+package org.zerhusen.properties.jwt;
+
+import org.hibernate.validator.constraints.NotEmpty;
+
+/**
+ * Created by glenn on 08.05.17.
+ */
+public class Authentication {
+    @NotEmpty
+    private String path;
+    @NotEmpty
+    private String refresh;
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getRefresh() {
+        return refresh;
+    }
+
+    public void setRefresh(String refresh) {
+        this.refresh = refresh;
+    }
+}

--- a/src/main/java/org/zerhusen/properties/jwt/Authentication.java
+++ b/src/main/java/org/zerhusen/properties/jwt/Authentication.java
@@ -2,10 +2,12 @@ package org.zerhusen.properties.jwt;
 
 import org.hibernate.validator.constraints.NotEmpty;
 
+import java.io.Serializable;
+
 /**
  * Created by glenn on 08.05.17.
  */
-public class Authentication {
+public class Authentication implements Serializable {
     @NotEmpty
     private String path;
     @NotEmpty

--- a/src/main/java/org/zerhusen/properties/jwt/JwtProperties.java
+++ b/src/main/java/org/zerhusen/properties/jwt/JwtProperties.java
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.stereotype.Component;
 
 import javax.validation.Valid;
+import java.io.Serializable;
 
 /**
  * Created by glenn on 08.05.17.
@@ -13,7 +14,7 @@ import javax.validation.Valid;
 
 @Component
 @ConfigurationProperties(prefix = "jwt")
-public class JwtProperties {
+public class JwtProperties implements Serializable {
     @NotEmpty
     private String header;
     @NotEmpty

--- a/src/main/java/org/zerhusen/properties/jwt/JwtProperties.java
+++ b/src/main/java/org/zerhusen/properties/jwt/JwtProperties.java
@@ -1,0 +1,58 @@
+package org.zerhusen.properties.jwt;
+
+import org.hibernate.validator.constraints.NotEmpty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.stereotype.Component;
+
+import javax.validation.Valid;
+
+/**
+ * Created by glenn on 08.05.17.
+ */
+
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+    @NotEmpty
+    private String header;
+    @NotEmpty
+    private String secret;
+    @Valid
+    private Long expiration;
+
+    @NestedConfigurationProperty
+    private Route route;
+
+    public String getHeader() {
+        return header;
+    }
+
+    public void setHeader(String header) {
+        this.header = header;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public Long getExpiration() {
+        return expiration;
+    }
+
+    public void setExpiration(Long expiration) {
+        this.expiration = expiration;
+    }
+
+    public Route getRoute() {
+        return route;
+    }
+
+    public void setRoute(Route route) {
+        this.route = route;
+    }
+}

--- a/src/main/java/org/zerhusen/properties/jwt/Route.java
+++ b/src/main/java/org/zerhusen/properties/jwt/Route.java
@@ -2,10 +2,12 @@ package org.zerhusen.properties.jwt;
 
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
+import java.io.Serializable;
+
 /**
  * Created by glenn on 08.05.17.
  */
-public class Route {
+public class Route implements Serializable {
     @NestedConfigurationProperty
     private Authentication authentication;
 

--- a/src/main/java/org/zerhusen/properties/jwt/Route.java
+++ b/src/main/java/org/zerhusen/properties/jwt/Route.java
@@ -1,0 +1,19 @@
+package org.zerhusen.properties.jwt;
+
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+/**
+ * Created by glenn on 08.05.17.
+ */
+public class Route {
+    @NestedConfigurationProperty
+    private Authentication authentication;
+
+    public Authentication getAuthentication() {
+        return authentication;
+    }
+
+    public void setAuthentication(Authentication authentication) {
+        this.authentication = authentication;
+    }
+}

--- a/src/main/java/org/zerhusen/security/JwtAuthenticationTokenFilter.java
+++ b/src/main/java/org/zerhusen/security/JwtAuthenticationTokenFilter.java
@@ -3,13 +3,13 @@ package org.zerhusen.security;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.zerhusen.properties.jwt.JwtProperties;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -23,13 +23,12 @@ public class JwtAuthenticationTokenFilter extends OncePerRequestFilter {
 
     private UserDetailsService userDetailsService;
     private JwtTokenUtil jwtTokenUtil;
-
-    @Value("${jwt.header}")
-    private String tokenHeader;
+    private JwtProperties jwtProperties;
 
     @Autowired
-    public void setUserDetailsService(UserDetailsService userDetailsService) {
+    public void setUserDetailsService(UserDetailsService userDetailsService, JwtProperties jwtProperties) {
         this.userDetailsService = userDetailsService;
+        this.jwtProperties = jwtProperties;
     }
 
     @Autowired
@@ -39,7 +38,7 @@ public class JwtAuthenticationTokenFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
-        String authToken = request.getHeader(this.tokenHeader);
+        String authToken = request.getHeader(jwtProperties.getHeader());
         // authToken.startsWith("Bearer ")
         // String authToken = header.substring(7);
         String username = jwtTokenUtil.getUsernameFromToken(authToken);

--- a/src/main/java/org/zerhusen/security/JwtAuthenticationTokenFilter.java
+++ b/src/main/java/org/zerhusen/security/JwtAuthenticationTokenFilter.java
@@ -1,11 +1,5 @@
 package org.zerhusen.security;
 
-import java.io.IOException;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,18 +11,31 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
 public class JwtAuthenticationTokenFilter extends OncePerRequestFilter {
 
     private final Log logger = LogFactory.getLog(this.getClass());
 
-    @Autowired
     private UserDetailsService userDetailsService;
-
-    @Autowired
     private JwtTokenUtil jwtTokenUtil;
 
     @Value("${jwt.header}")
     private String tokenHeader;
+
+    @Autowired
+    public void setUserDetailsService(UserDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Autowired
+    public void setJwtTokenUtil(JwtTokenUtil jwtTokenUtil) {
+        this.jwtTokenUtil = jwtTokenUtil;
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {

--- a/src/main/java/org/zerhusen/security/JwtTokenUtil.java
+++ b/src/main/java/org/zerhusen/security/JwtTokenUtil.java
@@ -93,7 +93,7 @@ public class JwtTokenUtil implements Serializable {
     }
 
     private Date generateExpirationDate() {
-        return new Date(System.currentTimeMillis() + jwtProperties.getExpiration());
+        return new Date(System.currentTimeMillis() + jwtProperties.getExpiration() * 1000);
     }
 
     private Boolean isTokenExpired(String token) {

--- a/src/main/java/org/zerhusen/security/JwtTokenUtil.java
+++ b/src/main/java/org/zerhusen/security/JwtTokenUtil.java
@@ -3,10 +3,11 @@ package org.zerhusen.security;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mobile.device.Device;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import org.zerhusen.properties.jwt.JwtProperties;
 
 import java.io.Serializable;
 import java.util.Date;
@@ -27,11 +28,12 @@ public class JwtTokenUtil implements Serializable {
     private static final String AUDIENCE_MOBILE = "mobile";
     private static final String AUDIENCE_TABLET = "tablet";
 
-    @Value("${jwt.secret}")
-    private String secret;
+    private JwtProperties jwtProperties;
 
-    @Value("${jwt.expiration}")
-    private Long expiration;
+    @Autowired
+    public JwtTokenUtil(JwtProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+    }
 
     public String getUsernameFromToken(String token) {
         String username;
@@ -81,7 +83,7 @@ public class JwtTokenUtil implements Serializable {
         Claims claims;
         try {
             claims = Jwts.parser()
-                    .setSigningKey(secret)
+                    .setSigningKey(jwtProperties.getSecret())
                     .parseClaimsJws(token)
                     .getBody();
         } catch (Exception e) {
@@ -91,7 +93,7 @@ public class JwtTokenUtil implements Serializable {
     }
 
     private Date generateExpirationDate() {
-        return new Date(System.currentTimeMillis() + expiration);
+        return new Date(System.currentTimeMillis() + jwtProperties.getExpiration());
     }
 
     private Boolean isTokenExpired(String token) {
@@ -132,7 +134,7 @@ public class JwtTokenUtil implements Serializable {
         return Jwts.builder()
                 .setClaims(claims)
                 .setExpiration(generateExpirationDate())
-                .signWith(SignatureAlgorithm.HS512, secret)
+                .signWith(SignatureAlgorithm.HS512, jwtProperties.getSecret())
                 .compact();
     }
 

--- a/src/main/java/org/zerhusen/security/JwtTokenUtil.java
+++ b/src/main/java/org/zerhusen/security/JwtTokenUtil.java
@@ -91,7 +91,7 @@ public class JwtTokenUtil implements Serializable {
     }
 
     private Date generateExpirationDate() {
-        return new Date(System.currentTimeMillis() + expiration * 1000);
+        return new Date(System.currentTimeMillis() + expiration);
     }
 
     private Boolean isTokenExpired(String token) {

--- a/src/main/java/org/zerhusen/security/controller/AuthenticationRestController.java
+++ b/src/main/java/org/zerhusen/security/controller/AuthenticationRestController.java
@@ -28,14 +28,16 @@ public class AuthenticationRestController {
     @Value("${jwt.header}")
     private String tokenHeader;
 
-    @Autowired
     private AuthenticationManager authenticationManager;
-
-    @Autowired
     private JwtTokenUtil jwtTokenUtil;
+    private UserDetailsService userDetailsService;
 
     @Autowired
-    private UserDetailsService userDetailsService;
+    public AuthenticationRestController(AuthenticationManager authenticationManager, JwtTokenUtil jwtTokenUtil, UserDetailsService userDetailsService) {
+        this.authenticationManager = authenticationManager;
+        this.jwtTokenUtil = jwtTokenUtil;
+        this.userDetailsService = userDetailsService;
+    }
 
     @RequestMapping(value = "${jwt.route.authentication.path}", method = RequestMethod.POST)
     public ResponseEntity<?> createAuthenticationToken(@RequestBody JwtAuthenticationRequest authenticationRequest, Device device) throws AuthenticationException {

--- a/src/main/java/org/zerhusen/security/controller/AuthenticationRestController.java
+++ b/src/main/java/org/zerhusen/security/controller/AuthenticationRestController.java
@@ -1,7 +1,6 @@
 package org.zerhusen.security.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mobile.device.Device;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -15,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+import org.zerhusen.properties.jwt.JwtProperties;
 import org.zerhusen.security.JwtAuthenticationRequest;
 import org.zerhusen.security.JwtTokenUtil;
 import org.zerhusen.security.JwtUser;
@@ -25,18 +25,17 @@ import javax.servlet.http.HttpServletRequest;
 @RestController
 public class AuthenticationRestController {
 
-    @Value("${jwt.header}")
-    private String tokenHeader;
-
     private AuthenticationManager authenticationManager;
     private JwtTokenUtil jwtTokenUtil;
     private UserDetailsService userDetailsService;
+    private JwtProperties jwtProperties;
 
     @Autowired
-    public AuthenticationRestController(AuthenticationManager authenticationManager, JwtTokenUtil jwtTokenUtil, UserDetailsService userDetailsService) {
+    public AuthenticationRestController(AuthenticationManager authenticationManager, JwtTokenUtil jwtTokenUtil, UserDetailsService userDetailsService, JwtProperties jwtProperties) {
         this.authenticationManager = authenticationManager;
         this.jwtTokenUtil = jwtTokenUtil;
         this.userDetailsService = userDetailsService;
+        this.jwtProperties = jwtProperties;
     }
 
     @RequestMapping(value = "${jwt.route.authentication.path}", method = RequestMethod.POST)
@@ -61,7 +60,7 @@ public class AuthenticationRestController {
 
     @RequestMapping(value = "${jwt.route.authentication.refresh}", method = RequestMethod.GET)
     public ResponseEntity<?> refreshAndGetAuthenticationToken(HttpServletRequest request) {
-        String token = request.getHeader(tokenHeader);
+        String token = request.getHeader(jwtProperties.getHeader());
         String username = jwtTokenUtil.getUsernameFromToken(token);
         JwtUser user = (JwtUser) userDetailsService.loadUserByUsername(username);
 

--- a/src/main/java/org/zerhusen/security/controller/UserRestController.java
+++ b/src/main/java/org/zerhusen/security/controller/UserRestController.java
@@ -17,11 +17,14 @@ public class UserRestController {
     @Value("${jwt.header}")
     private String tokenHeader;
 
-    @Autowired
     private JwtTokenUtil jwtTokenUtil;
+    private UserDetailsService userDetailsService;
 
     @Autowired
-    private UserDetailsService userDetailsService;
+    public UserRestController(JwtTokenUtil jwtTokenUtil, UserDetailsService userDetailsService) {
+        this.jwtTokenUtil = jwtTokenUtil;
+        this.userDetailsService = userDetailsService;
+    }
 
     @RequestMapping(value = "user", method = RequestMethod.GET)
     public JwtUser getAuthenticatedUser(HttpServletRequest request) {

--- a/src/main/java/org/zerhusen/security/controller/UserRestController.java
+++ b/src/main/java/org/zerhusen/security/controller/UserRestController.java
@@ -1,11 +1,11 @@
 package org.zerhusen.security.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+import org.zerhusen.properties.jwt.JwtProperties;
 import org.zerhusen.security.JwtTokenUtil;
 import org.zerhusen.security.JwtUser;
 
@@ -14,21 +14,20 @@ import javax.servlet.http.HttpServletRequest;
 @RestController
 public class UserRestController {
 
-    @Value("${jwt.header}")
-    private String tokenHeader;
-
     private JwtTokenUtil jwtTokenUtil;
     private UserDetailsService userDetailsService;
+    private JwtProperties jwtProperties;
 
     @Autowired
-    public UserRestController(JwtTokenUtil jwtTokenUtil, UserDetailsService userDetailsService) {
+    public UserRestController(JwtTokenUtil jwtTokenUtil, UserDetailsService userDetailsService, JwtProperties jwtProperties) {
         this.jwtTokenUtil = jwtTokenUtil;
         this.userDetailsService = userDetailsService;
+        this.jwtProperties = jwtProperties;
     }
 
     @RequestMapping(value = "user", method = RequestMethod.GET)
     public JwtUser getAuthenticatedUser(HttpServletRequest request) {
-        String token = request.getHeader(tokenHeader);
+        String token = request.getHeader(jwtProperties.getHeader());
         String username = jwtTokenUtil.getUsernameFromToken(token);
         JwtUser user = (JwtUser) userDetailsService.loadUserByUsername(username);
         return user;

--- a/src/main/java/org/zerhusen/security/service/JwtUserDetailsServiceImpl.java
+++ b/src/main/java/org/zerhusen/security/service/JwtUserDetailsServiceImpl.java
@@ -15,8 +15,12 @@ import org.zerhusen.security.repository.UserRepository;
 @Service
 public class JwtUserDetailsServiceImpl implements UserDetailsService {
 
-    @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    public JwtUserDetailsServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
 jwt:
   header: Authorization
   secret: mySecret
-  expiration: 604800
+  expiration: 10000
   route:
     authentication:
       path: auth

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
 jwt:
   header: Authorization
   secret: mySecret
-  expiration: 10000
+  expiration: 604800
   route:
     authentication:
       path: auth

--- a/src/test/java/org/zerhusen/JwtDemoApplicationTests.java
+++ b/src/test/java/org/zerhusen/JwtDemoApplicationTests.java
@@ -3,10 +3,11 @@ package org.zerhusen;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = JwtDemoApplication.class)
+@SpringBootTest
 public class JwtDemoApplicationTests {
 
 	@Test

--- a/src/test/java/org/zerhusen/JwtDemoApplicationTests.java
+++ b/src/test/java/org/zerhusen/JwtDemoApplicationTests.java
@@ -2,7 +2,6 @@ package org.zerhusen;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 

--- a/src/test/java/org/zerhusen/security/JwtTokenUtilTest.java
+++ b/src/test/java/org/zerhusen/security/JwtTokenUtilTest.java
@@ -3,15 +3,14 @@ package org.zerhusen.security;
 import org.assertj.core.util.DateUtil;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.util.ReflectionUtils;
+import org.zerhusen.properties.jwt.JwtProperties;
 
-import java.lang.reflect.Field;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by stephan on 10.09.16.
@@ -19,12 +18,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JwtTokenUtilTest {
 
     private JwtTokenUtil jwtTokenUtil;
+    private JwtProperties jwtProperties;
 
     @Before
     public void init() {
-        jwtTokenUtil = new JwtTokenUtil();
-        ReflectionTestUtils.setField(jwtTokenUtil, "expiration", 3600000L);
-        ReflectionTestUtils.setField(jwtTokenUtil, "secret", "mySecret");
+        jwtProperties = mock(JwtProperties.class);
+        jwtTokenUtil = new JwtTokenUtil(jwtProperties);
+        when(jwtProperties.getExpiration()).thenReturn(3600000L);
+        when(jwtProperties.getSecret()).thenReturn("mySecret");
     }
 
     @Test


### PR DESCRIPTION
- updated Spring boot version and removed the deprecated annotation.
- replaced Field Injection with constructor and setter injection.
- replaced the usage of @Value with a Properties bean.
This made it possible to replace the usage of ReflectionTestUtils with a mock of the Properties bean.