### PR TITLE
Remove duplicate dependency in pom: spring-boot-starter-test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,11 +72,6 @@
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>io.jsonwebtoken</groupId>


### PR DESCRIPTION
Due to duplicate of dependency in pom: `spring-boot-starter-test`,
warning messages below outputs when running `mvn xxx` commands.
This pull request removes duplicate dependency to fix this problem.

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.zerhusen:jwt-spring-security-demo:jar:0.1.0
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.springframework.boot:spring-boot-starter-test:jar -> duplicate declaration of version (?) @ line 87, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```