### PR TITLE
update expiration time of new refreshed token

### DIFF
--- a/src/main/java/org/zerhusen/security/JwtTokenUtil.java
+++ b/src/main/java/org/zerhusen/security/JwtTokenUtil.java
@@ -122,7 +122,9 @@ public class JwtTokenUtil implements Serializable {
 
     public String refreshToken(String token) {
         final Claims claims = getAllClaimsFromToken(token);
+        final Date expirationDate = new Date(createdDate.getTime() + expiration * 1000);
         claims.setIssuedAt(timeProvider.now());
+        claims.setExpiration(expirationDate)
         return doRefreshToken(claims);
     }
 


### PR DESCRIPTION
If I am not wrong, you are not using oAuth2. so refresh token is simply updating the token with new issued time but not updating expiration time. Just have a look.

Line No 123. method name : refreshToken()