### PR TITLE
Fix for issue #65

### DIFF
--- a/src/main/java/org/zerhusen/security/controller/AuthenticationRestController.java
+++ b/src/main/java/org/zerhusen/security/controller/AuthenticationRestController.java
@@ -59,7 +59,8 @@ public class AuthenticationRestController {
 
     @RequestMapping(value = "${jwt.route.authentication.refresh}", method = RequestMethod.GET)
     public ResponseEntity<?> refreshAndGetAuthenticationToken(HttpServletRequest request) {
-        String token = request.getHeader(tokenHeader);
+        String authToken = request.getHeader(tokenHeader);
+        final String token = authToken.substring(7);
         String username = jwtTokenUtil.getUsernameFromToken(token);
         JwtUser user = (JwtUser) userDetailsService.loadUserByUsername(username);
 

--- a/src/test/java/org/zerhusen/rest/AuthenticationRestControllerTest.java
+++ b/src/test/java/org/zerhusen/rest/AuthenticationRestControllerTest.java
@@ -97,7 +97,8 @@ public class AuthenticationRestControllerTest {
 
         when(this.jwtTokenUtil.canTokenBeRefreshed(any(), any())).thenReturn(true);
 
-        this.mvc.perform(get("/refresh"))
+        this.mvc.perform(get("/refresh")
+                .header("Authorization", "Bearer 5d1103e-b3e1-4ae9-b606-46c9c1bc915a"))
                 .andExpect(status().is2xxSuccessful());
     }
 
@@ -124,7 +125,8 @@ public class AuthenticationRestControllerTest {
 
         when(this.jwtTokenUtil.canTokenBeRefreshed(any(), any())).thenReturn(true);
 
-        this.mvc.perform(get("/refresh"))
+        this.mvc.perform(get("/refresh")
+                .header("Authorization", "Bearer 5d1103e-b3e1-4ae9-b606-46c9c1bc915a"))
                 .andExpect(status().is2xxSuccessful());
     }
 


### PR DESCRIPTION
- Fixed the issue on '/refresh' API endpoint by extracting only the JWT token excluding Bearer as part of the Authorization token value.

- Updated couple of test cases which failed due to the fix, added dummy header for those API end points which solves the issue.