### PR TITLE
make the demo work with JAVA 9, …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>


### PR DESCRIPTION
…because JAXB API's are considered to be Java EE APIs, and therefore are no longer contained on the default class path in Java SE 9

https://stackoverflow.com/a/43574427/2125520