### PR TITLE
catch `UsernameNotFoundException` and handle it

### DIFF
--- a/src/main/java/org/zerhusen/security/JwtAuthorizationTokenFilter.java
+++ b/src/main/java/org/zerhusen/security/JwtAuthorizationTokenFilter.java
@@ -56,8 +56,15 @@ public class JwtAuthorizationTokenFilter extends OncePerRequestFilter {
             logger.debug("security context was null, so authorizating user");
 
             // It is not compelling necessary to load the use details from the database. You could also store the information
-            // in the token and read it from it. It's up to you ;)
-            UserDetails userDetails = this.userDetailsService.loadUserByUsername(username);
+            // in the token and read it from it. It's up to you ;)            
+            UserDetails userDetails;
+            try {
+                userDetails = userDetailsService.loadUserByUsername(username);
+            } catch (UsernameNotFoundException e) {
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
+                return;
+            }
+
 
             // For simple validation it is completely sufficient to just check the token integrity. You don't have to call
             // the database compellingly. Again it's up to you ;)

--- a/src/main/java/org/zerhusen/security/JwtAuthorizationTokenFilter.java
+++ b/src/main/java/org/zerhusen/security/JwtAuthorizationTokenFilter.java
@@ -1,11 +1,5 @@
 package org.zerhusen.security;
 
-import java.io.IOException;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import io.jsonwebtoken.ExpiredJwtException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,8 +7,15 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 public class JwtAuthorizationTokenFilter extends OncePerRequestFilter {
 

--- a/src/main/java/org/zerhusen/security/JwtAuthorizationTokenFilter.java
+++ b/src/main/java/org/zerhusen/security/JwtAuthorizationTokenFilter.java
@@ -3,6 +3,7 @@ package org.zerhusen.security;
 import io.jsonwebtoken.ExpiredJwtException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -28,7 +29,7 @@ public class JwtAuthorizationTokenFilter extends OncePerRequestFilter {
     private final JwtTokenUtil jwtTokenUtil;
     private final String tokenHeader;
 
-    public JwtAuthorizationTokenFilter(UserDetailsService userDetailsService, JwtTokenUtil jwtTokenUtil, @Value("${jwt.header}") String tokenHeader) {
+    public JwtAuthorizationTokenFilter(@Qualifier("jwtUserDetailsService") UserDetailsService userDetailsService, JwtTokenUtil jwtTokenUtil, @Value("${jwt.header}") String tokenHeader) {
         this.userDetailsService = userDetailsService;
         this.jwtTokenUtil = jwtTokenUtil;
         this.tokenHeader = tokenHeader;
@@ -47,7 +48,7 @@ public class JwtAuthorizationTokenFilter extends OncePerRequestFilter {
             try {
                 username = jwtTokenUtil.getUsernameFromToken(authToken);
             } catch (IllegalArgumentException e) {
-                logger.error("an error occured during getting username from token", e);
+                logger.error("an error occurred during getting username from token", e);
             } catch (ExpiredJwtException e) {
                 logger.warn("the token is expired and not valid anymore", e);
             }
@@ -57,7 +58,7 @@ public class JwtAuthorizationTokenFilter extends OncePerRequestFilter {
 
         logger.debug("checking authentication for user '{}'", username);
         if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-            logger.debug("security context was null, so authorizating user");
+            logger.debug("security context was null, so authorizing user");
 
             // It is not compelling necessary to load the use details from the database. You could also store the information
             // in the token and read it from it. It's up to you ;)            
@@ -75,7 +76,7 @@ public class JwtAuthorizationTokenFilter extends OncePerRequestFilter {
             if (jwtTokenUtil.validateToken(authToken, userDetails)) {
                 UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                logger.info("authorizated user '{}', setting security context", username);
+                logger.info("authorized user '{}', setting security context", username);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         }

--- a/src/main/java/org/zerhusen/security/service/JwtUserDetailsService.java
+++ b/src/main/java/org/zerhusen/security/service/JwtUserDetailsService.java
@@ -9,7 +9,7 @@ import org.zerhusen.model.security.User;
 import org.zerhusen.security.JwtUserFactory;
 import org.zerhusen.security.repository.UserRepository;
 
-@Service
+@Service("jwtUserDetailsService")
 public class JwtUserDetailsService implements UserDetailsService {
 
     @Autowired


### PR DESCRIPTION
if someone request with unexpired jwt token of deleted user

userDetailsService.loadUserByUsername(String username) method would throws `UsernameNotFoundException`

and if the filter class doesn't catch this, `500 Internal Server Error` muse be occurred.

so we should to catch this, and respond with status `401 Unauthorized`